### PR TITLE
Set PeerHostname/PeerPort rather than URL based on connection.

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -5,8 +5,10 @@ package nethttp
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptrace"
+	"strconv"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -159,7 +161,15 @@ func (h *Tracer) clientTrace() *httptrace.ClientTrace {
 }
 
 func (h *Tracer) getConn(hostPort string) {
-	ext.HTTPUrl.Set(h.sp, hostPort)
+	host, portString, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		ext.PeerHostname.Set(h.sp, hostPort)
+	} else {
+		ext.PeerHostname.Set(h.sp, host)
+		if port, err := strconv.Atoi(portString); err != nil {
+			ext.PeerPort.Set(h.sp, uint16(port))
+		}
+	}
 	h.sp.LogEvent("Get conn")
 }
 


### PR DESCRIPTION
Based on the gokit code:

https://github.com/go-kit/kit/blob/023cbf047fba5be6bcd44e80f2558a8e7554e8ab/tracing/opentracing/http.go#L26

Fixes https://github.com/opentracing-contrib/go-stdlib/issues/2