### PR TITLE
Allow Hijacking on the statusCodeTracker

### DIFF
--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -3,6 +3,9 @@
 package nethttp
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -17,6 +20,14 @@ type statusCodeTracker struct {
 func (w *statusCodeTracker) WriteHeader(status int) {
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusCodeTracker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("statusCodeTracker: can't cast parent ResponseWriter to Hijacker")
+	}
+	return hj.Hijack()
 }
 
 type mwOptions struct {

--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -4,13 +4,15 @@ package nethttp
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 )
+
+var ErrCannotHijack = errors.New("statusCodeTracker: can't cast parent ResponseWriter to Hijacker")
 
 type statusCodeTracker struct {
 	http.ResponseWriter
@@ -25,7 +27,7 @@ func (w *statusCodeTracker) WriteHeader(status int) {
 func (w *statusCodeTracker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hj, ok := w.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("statusCodeTracker: can't cast parent ResponseWriter to Hijacker")
+		return nil, nil, ErrCannotHijack
 	}
 	return hj.Hijack()
 }


### PR DESCRIPTION
After adding opentracing middleware to our app, we found websockets broke as we couldn't hijack the `ResponseWriter`.  This PR fixed that.

I was expecting the embedding of `http.ResponseWriter` in the `statusCodeTracker` to allow this, but we also use some Prometheus & logging middleware that wraps the `ResponseWriter`[1], and it seems the embedded / casting  trick doesn't work transitively [2].

[1] https://github.com/weaveworks/common/blob/master/middleware/logging.go#L61
[2] https://play.golang.org/p/5GOVaXlO8T