### PR TITLE
Added fix to default opentracing RoundTrip

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -121,7 +121,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	tracer, ok := req.Context().Value(keyTracer).(*Tracer)
 	if !ok {
-		return rt.RoundTrip(req)
+		req, tracer = TraceRequest(
+			opentracing.GlobalTracer(),
+			req,
+		)
 	}
 
 	tracer.start(req)


### PR DESCRIPTION
This PR addresses issue #29 

It uses the GlobalTracer by default if no other is found. Tests pass. 

Is span.Finish() idempotent? Because there's a single case where this trace could remain open, that is unfinished.