### PR TITLE
add middleware option to pass span filter function to filter requests

### DIFF
--- a/nethttp/server_test.go
+++ b/nethttp/server_test.go
@@ -3,6 +3,8 @@ package nethttp
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -103,6 +105,57 @@ func TestSpanObserverOption(t *testing.T) {
 				if tag := spans[0].Tag(k); v != tag.(string) {
 					t.Fatalf("got %v tag, expected %v", tag, v)
 				}
+			}
+		})
+	}
+}
+
+func TestSpanFilterOption(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/root", func(w http.ResponseWriter, r *http.Request) {})
+
+	spanFilterfn := func(r *http.Request) bool {
+		return !strings.HasPrefix(r.Header.Get("User-Agent"), "kube-probe")
+	}
+	noAgentReq, _ := http.NewRequest("GET", "/root", nil)
+	noAgentReq.Header.Del("User-Agent")
+	probeReq1, _ := http.NewRequest("GET", "/root", nil)
+	probeReq1.Header.Add("User-Agent", "kube-probe/1.12")
+	probeReq2, _ := http.NewRequest("GET", "/root", nil)
+	probeReq2.Header.Add("User-Agent", "kube-probe/9.99")
+	postmanReq, _ := http.NewRequest("GET", "/root", nil)
+	postmanReq.Header.Add("User-Agent", "PostmanRuntime/7.3.0")
+	tests := []struct {
+		options            []MWOption
+		request            *http.Request
+		opName             string
+		ExpectToCreateSpan bool
+	}{
+		{nil, noAgentReq, "No filter", true},
+		{[]MWOption{MWSpanFilter(spanFilterfn)}, noAgentReq, "No User-Agent", true},
+		{[]MWOption{MWSpanFilter(spanFilterfn)}, probeReq1, "User-Agent: kube-probe/1.12", false},
+		{[]MWOption{MWSpanFilter(spanFilterfn)}, probeReq2, "User-Agent: kube-probe/9.99", false},
+		{[]MWOption{MWSpanFilter(spanFilterfn)}, postmanReq, "User-Agent: PostmanRuntime/7.3.0", true},
+	}
+
+	for _, tt := range tests {
+		testCase := tt
+		t.Run(testCase.opName, func(t *testing.T) {
+			tr := &mocktracer.MockTracer{}
+			mw := Middleware(tr, mux, testCase.options...)
+			srv := httptest.NewServer(mw)
+			defer srv.Close()
+
+			client := &http.Client{}
+			testCase.request.URL, _ = url.Parse(srv.URL)
+			_, err := client.Do(testCase.request)
+			if err != nil {
+				t.Fatalf("server returned error: %v", err)
+			}
+
+			spans := tr.FinishedSpans()
+			if spanCreated := len(spans) == 1; spanCreated != testCase.ExpectToCreateSpan {
+				t.Fatalf("spanCreated %t, ExpectToCreateSpan %t", spanCreated, testCase.ExpectToCreateSpan)
 			}
 		})
 	}


### PR DESCRIPTION
I added a middleware option to filter certain requests from creating a span.
One use case could be when a user doesn’t want spans to be created by requests from kube-probe, which constantly polls, for example.
Please let me know your thoughts on this.