### PR TITLE
Support customising the http.url tag (server side)

### DIFF
--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -4,6 +4,7 @@ package nethttp
 
 import (
 	"net/http"
+	"net/url"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -13,6 +14,7 @@ type mwOptions struct {
 	opNameFunc    func(r *http.Request) string
 	spanFilter    func(r *http.Request) bool
 	spanObserver  func(span opentracing.Span, r *http.Request)
+	urlTagFunc    func(u *url.URL) string
 	componentName string
 }
 
@@ -49,6 +51,15 @@ func MWSpanFilter(f func(r *http.Request) bool) MWOption {
 func MWSpanObserver(f func(span opentracing.Span, r *http.Request)) MWOption {
 	return func(options *mwOptions) {
 		options.spanObserver = f
+	}
+}
+
+// MWURLTagFunc returns a MWOption that uses given function f
+// to set the span's http.url tag. Can be used to change the default
+// http.url tag, eg to redact sensitive information.
+func MWURLTagFunc(f func(u *url.URL) string) MWOption {
+	return func(options *mwOptions) {
+		options.urlTagFunc = f
 	}
 }
 
@@ -90,6 +101,9 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		},
 		spanFilter:   func(r *http.Request) bool { return true },
 		spanObserver: func(span opentracing.Span, r *http.Request) {},
+		urlTagFunc: func(u *url.URL) string {
+			return u.String()
+		},
 	}
 	for _, opt := range options {
 		opt(&opts)
@@ -102,7 +116,7 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		ctx, _ := tr.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
 		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx))
 		ext.HTTPMethod.Set(sp, r.Method)
-		ext.HTTPUrl.Set(sp, r.URL.String())
+		ext.HTTPUrl.Set(sp, opts.urlTagFunc(r.URL))
 		opts.spanObserver(sp, r)
 
 		// set component name, use "net/http" if caller does not specify


### PR DESCRIPTION
This may be useful where the url contains sensitive information.

This allows url tags such as:

 http.url: https://Aladdin:OpenSesame@www.example.com/index.html
 http.url: https://www.example.com?foo=bar&token=123

to be redacted:

 http.url: https://xxx:xxx@www.example.com/index.html
 http.url: https://www.example.com?foo=bar&token=***

This partially addresses:

  https://github.com/opentracing-contrib/go-stdlib/issues/33