### PR TITLE
fix risk of panic in http.HandlerFunc

### DIFF
--- a/nethttp/status-code-tracker-old.go
+++ b/nethttp/status-code-tracker-old.go
@@ -9,12 +9,22 @@ import (
 
 type statusCodeTracker struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteheader bool
 }
 
 func (w *statusCodeTracker) WriteHeader(status int) {
 	w.status = status
+	w.wroteheader = true
 	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusCodeTracker) Write(b []byte) (int, error) {
+	if !w.wroteheader {
+		w.wroteheader = true
+		w.status = 200
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 // wrappedResponseWriter returns a wrapped version of the original

--- a/nethttp/status-code-tracker.go
+++ b/nethttp/status-code-tracker.go
@@ -9,12 +9,22 @@ import (
 
 type statusCodeTracker struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteheader bool
 }
 
 func (w *statusCodeTracker) WriteHeader(status int) {
 	w.status = status
+	w.wroteheader = true
 	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusCodeTracker) Write(b []byte) (int, error) {
+	if !w.wroteheader {
+		w.wroteheader = true
+		w.status = 200
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 // wrappedResponseWriter returns a wrapped version of the original


### PR DESCRIPTION
In func MiddlewareFunc, if `h http.HandlerFunc` panic, then `span.Finish` would not be executed. 
```go
//...
	fn := func(w http.ResponseWriter, r *http.Request) {
		if !opts.spanFilter(r) {
			h(w, r)
			return
		}
		ctx, _ := tr.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx))
		ext.HTTPMethod.Set(sp, r.Method)
		ext.HTTPUrl.Set(sp, opts.urlTagFunc(r.URL))
		opts.spanObserver(sp, r)

		// set component name, use "net/http" if caller does not specify
		componentName := opts.componentName
		if componentName == "" {
			componentName = defaultComponentName
		}
		ext.Component.Set(sp, componentName)

		sct := &statusCodeTracker{w, 200}
		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))

		h(sct.wrappedResponseWriter(), r)

		ext.HTTPStatusCode.Set(sp, uint16(sct.status))
		sp.Finish()
	}
//...
```