### PR TITLE
Add TracerFromRequest method

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -113,14 +113,24 @@ func (c closeTracker) Close() error {
 	return err
 }
 
+// TracerFromRequest retrieves the Tracer from the request. If the request does
+// not have a Tracer it will return nil.
+func TracerFromRequest(req *http.Request) *Tracer {
+	tr, ok := req.Context().Value(keyTracer).(*Tracer)
+	if !ok {
+		return nil
+	}
+	return tr
+}
+
 // RoundTrip implements the RoundTripper interface.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt := t.RoundTripper
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
-	tracer, ok := req.Context().Value(keyTracer).(*Tracer)
-	if !ok {
+	tracer := TracerFromRequest(req)
+	if tracer == nil {
 		return rt.RoundTrip(req)
 	}
 

--- a/nethttp/client_test.go
+++ b/nethttp/client_test.go
@@ -99,3 +99,23 @@ func TestClientTrace(t *testing.T) {
 		}
 	}
 }
+
+func TestTracerFromRequest(t *testing.T) {
+	req, err := http.NewRequest("GET", "foobar", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ht := TracerFromRequest(req)
+	if ht != nil {
+		t.Fatal("request should not have a tracer yet")
+	}
+
+	tr := &mocktracer.MockTracer{}
+	req, expected := TraceRequest(tr, req)
+
+	ht = TracerFromRequest(req)
+	if ht != expected {
+		t.Fatalf("got %v expected %v", ht, expected)
+	}
+}


### PR DESCRIPTION
This method allows a user to check if a request is already being traced
and add extra data to the spans if they desire.

Code like this would be helpful for adding span data from within a RoundTrip call, or to make sure every RoundTrip is instrumented even if not wrapped in TraceRequest.