### PR TITLE
Add ClientSpanObserver and set error tag on status code >= 500

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -148,6 +148,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 	ext.HTTPStatusCode.Set(tracer.sp, uint16(resp.StatusCode))
+	if resp.StatusCode >= http.StatusInternalServerError {
+		ext.Error.Set(tracer.sp, true)
+	}
 	if req.Method == "HEAD" {
 		tracer.sp.Finish()
 	} else {


### PR DESCRIPTION
This PR adds two improvements to the client workflow:
1. The span around a RoundTrip will now report as an error if the status code >=500.
1. You can pass a ClientSpanObserver (similar to the MWSpanObserver) to the ClientOptions.
   * Allows a user to add custom information to each of the RoundTrip spans.

cc @rscot231 