### PR TITLE
feat: Tracer in Transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/opentracing-contrib/go-stdlib
+
+go 1.12
+
+require (
+	github.com/opentracing/opentracing-go v1.1.0
+	github.com/stretchr/testify v1.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -98,11 +98,11 @@ func ClientSpanObserver(f func(span opentracing.Span, r *http.Request)) ClientOp
 // 		return nil
 // 	}
 func TraceRequest(tr opentracing.Tracer, req *http.Request, options ...ClientOption) (*http.Request, *Tracer) {
-	opts := &clientOptions{
+	opts := clientOptions{
 		spanObserver: func(_ opentracing.Span, _ *http.Request) {},
 	}
 	for _, opt := range options {
-		opt(opts)
+		opt(&opts)
 	}
 	ht := &Tracer{tr: tr, opts: opts}
 	ctx := req.Context()
@@ -184,7 +184,7 @@ type Tracer struct {
 	tr   opentracing.Tracer
 	root opentracing.Span
 	sp   opentracing.Span
-	opts *clientOptions
+	opts clientOptions
 }
 
 func (h *Tracer) start(req *http.Request) opentracing.Span {

--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -28,6 +28,7 @@ type Transport struct {
 	// The actual RoundTripper to use for the request. A nil
 	// RoundTripper defaults to http.DefaultTransport.
 	http.RoundTripper
+	Tracer opentracing.Tracer
 }
 
 type clientOptions struct {
@@ -140,7 +141,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
-	tracer := TracerFromRequest(req)
+
+	var tracer *Tracer
+	if t.Tracer != nil {
+		tracer = &Tracer{tr: t.Tracer}
+	} else {
+		tracer = TracerFromRequest(req)
+	}
+
 	if tracer == nil {
 		return rt.RoundTrip(req)
 	}

--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -98,9 +98,7 @@ func ClientSpanObserver(f func(span opentracing.Span, r *http.Request)) ClientOp
 // 		return nil
 // 	}
 func TraceRequest(tr opentracing.Tracer, req *http.Request, options ...ClientOption) (*http.Request, *Tracer) {
-	opts := clientOptions{
-		spanObserver: func(_ opentracing.Span, _ *http.Request) {},
-	}
+	opts := clientOptions{}
 	for _, opt := range options {
 		opt(&opts)
 	}
@@ -157,7 +155,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	ext.HTTPMethod.Set(tracer.sp, req.Method)
 	ext.HTTPUrl.Set(tracer.sp, req.URL.String())
-	tracer.opts.spanObserver(tracer.sp, req)
+
+	if tracer.opts.spanObserver != nil {
+		tracer.opts.spanObserver(tracer.sp, req)
+	}
 
 	carrier := opentracing.HTTPHeadersCarrier(req.Header)
 	tracer.sp.Tracer().Inject(tracer.sp.Context(), opentracing.HTTPHeaders, carrier)


### PR DESCRIPTION
Add `Tracer` argument to `nethttp.Transport`.
Fixes #29 