### PR TITLE
nethttp: treat empty response as success

### DIFF
--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -65,8 +65,7 @@ func MWURLTagFunc(f func(u *url.URL) string) MWOption {
 }
 
 // IgnorePanic disables panic hanling behavior. Unless this option is set,
-// the middleware will catch panic and set error=true tag on the span,
-// as well as HTTP status code 500.
+// the middleware will catch panic and set error=true tag on the span.
 func IgnorePanic() MWOption {
 	return func(options *mwOptions) {
 		options.ignorePanic = true

--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -131,21 +131,13 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 
 		defer func() {
 			ext.HTTPStatusCode.Set(sp, uint16(sct.status))
-			if sct.status >= http.StatusInternalServerError || sct.status == 0 {
+			if sct.status >= http.StatusInternalServerError {
 				ext.Error.Set(sp, true)
 			}
 			sp.Finish()
 		}()
 
-		func() {
-			defer func() {
-				if err := recover(); err != nil {
-					sct.status = 0
-					panic(err)
-				}
-			}()
-			h(sct.wrappedResponseWriter(), r)
-		}()
+		h(sct.wrappedResponseWriter(), r)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -123,8 +123,8 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx))
 		ext.HTTPMethod.Set(sp, r.Method)
 		ext.HTTPUrl.Set(sp, opts.urlTagFunc(r.URL))
-		opts.spanObserver(sp, r)
 		ext.Component.Set(sp, componentName)
+		opts.spanObserver(sp, r)
 
 		sct := &statusCodeTracker{ResponseWriter: w}
 		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))

--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -125,9 +125,9 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		ext.HTTPUrl.Set(sp, opts.urlTagFunc(r.URL))
 		opts.spanObserver(sp, r)
 		ext.Component.Set(sp, componentName)
-		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
 
 		sct := &statusCodeTracker{ResponseWriter: w}
+		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
 
 		defer func() {
 			panicErr := recover()

--- a/nethttp/server_test.go
+++ b/nethttp/server_test.go
@@ -257,14 +257,9 @@ func TestSpanErrorAndStatusCode(t *testing.T) {
 				t.Fatalf("got %d spans, expected %d", got, want)
 			}
 
-			spanTags := spans[0].Tags()
 			for k, v := range testCase.tags {
-				if tag, ok := spanTags[k]; ok {
-					if !reflect.DeepEqual(tag, v) {
-						t.Fatalf("tag %s: got %v, expected %v", k, tag, v)
-					}
-				} else {
-					t.Fatalf("did not find expected tag %s", k)
+				if tag := spans[0].Tag(k); !reflect.DeepEqual(tag, v) {
+					t.Fatalf("tag %s: got %v, expected %v", k, tag, v)
 				}
 			}
 		})

--- a/nethttp/server_test.go
+++ b/nethttp/server_test.go
@@ -339,12 +339,9 @@ func TestMiddlewareHandlerPanic(t *testing.T) {
 			if got, want := len(spans), 1; got != want {
 				t.Fatalf("got %d spans, expected %d", got, want)
 			}
-			if testCase.status > 0 {
-				t.Logf("expecting status %d", testCase.status)
-				actualStatus := spans[0].Tag(string(ext.HTTPStatusCode))
-				if !reflect.DeepEqual(testCase.status, actualStatus) {
-					t.Fatalf("got status code %v, expected %d", actualStatus, testCase.status)
-				}
+			actualStatus := spans[0].Tag(string(ext.HTTPStatusCode))
+			if testCase.status > 0 && !reflect.DeepEqual(testCase.status, actualStatus) {
+				t.Fatalf("got status code %v, expected %d", actualStatus, testCase.status)
 			}
 			actualErr, ok := spans[0].Tag(string(ext.Error)).(bool)
 			if !ok {

--- a/nethttp/status-code-tracker.go
+++ b/nethttp/status-code-tracker.go
@@ -22,7 +22,6 @@ func (w *statusCodeTracker) WriteHeader(status int) {
 func (w *statusCodeTracker) Write(b []byte) (int, error) {
 	if !w.wroteheader {
 		w.wroteheader = true
-		w.status = 200
 	}
 	return w.ResponseWriter.Write(b)
 }

--- a/nethttp/status-code-tracker.go
+++ b/nethttp/status-code-tracker.go
@@ -9,20 +9,15 @@ import (
 
 type statusCodeTracker struct {
 	http.ResponseWriter
-	status      int
-	wroteheader bool
+	status int
 }
 
 func (w *statusCodeTracker) WriteHeader(status int) {
 	w.status = status
-	w.wroteheader = true
 	w.ResponseWriter.WriteHeader(status)
 }
 
 func (w *statusCodeTracker) Write(b []byte) (int, error) {
-	if !w.wroteheader {
-		w.wroteheader = true
-	}
 	return w.ResponseWriter.Write(b)
 }
 


### PR DESCRIPTION
### Problem

Currently, tracers report errors in handlers that return an empty response, such as:

```go
mux := http.NewServeMux()
mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
  // nop
})
```

### solution

- set default StatusCode to 200
- set StatusCode to 0 when panic occurs (maintain compatibility)
