### PR TITLE
Update client.go: set peer.address tag from req.URL.Host; log hostPort in getConn()

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -282,7 +282,6 @@ func (h *Tracer) clientTrace() *httptrace.ClientTrace {
 }
 
 func (h *Tracer) getConn(hostPort string) {
-	ext.HTTPUrl.Set(h.sp, hostPort)
 	h.sp.LogFields(log.String("event", "GetConn"))
 }
 

--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -34,7 +34,7 @@ type Transport struct {
 type clientOptions struct {
 	operationName            string
 	componentName            string
-	urlTagFunc         func(u *url.URL) string
+	urlTagFunc               func(u *url.URL) string
 	disableClientTrace       bool
 	disableInjectSpanContext bool
 	spanObserver             func(span opentracing.Span, r *http.Request)
@@ -186,6 +186,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	ext.HTTPMethod.Set(tracer.sp, req.Method)
 	ext.HTTPUrl.Set(tracer.sp, tracer.opts.urlTagFunc(req.URL))
+	ext.PeerAddress.Set(tracer.sp, req.URL.Host)
 	tracer.opts.spanObserver(tracer.sp, req)
 
 	if !tracer.opts.disableInjectSpanContext {
@@ -282,7 +283,7 @@ func (h *Tracer) clientTrace() *httptrace.ClientTrace {
 }
 
 func (h *Tracer) getConn(hostPort string) {
-	h.sp.LogFields(log.String("event", "GetConn"))
+	h.sp.LogFields(log.String("event", "GetConn"), log.String("hostPort", hostPort))
 }
 
 func (h *Tracer) gotConn(info httptrace.GotConnInfo) {

--- a/nethttp/client_test.go
+++ b/nethttp/client_test.go
@@ -312,5 +312,12 @@ func TestClientCustomURL(t *testing.T) {
 		if got, want := tag, tt.tag; got != want {
 			t.Fatalf("got %s tag name, expected %s", got, want)
 		}
+		peerAddress, ok := clientSpan.Tags()["peer.address"]
+		if !ok {
+			t.Fatal("cannot find peer.address tag")
+		}
+		if peerAddress != srv.Listener.Addr().String() {
+			t.Fatalf("got %s want %s in peer.address tag", peerAddress, srv.Listener.Addr().String())
+		}
 	}
 }

--- a/nethttp/client_test.go
+++ b/nethttp/client_test.go
@@ -288,8 +288,8 @@ func TestClientCustomURL(t *testing.T) {
 		tag  string
 	}{
 		// These first cases fail early
-		{[]ClientOption{}, "/ok?token=a", srv.Listener.Addr().String()},
-		{[]ClientOption{URLTagFunc(fn)}, "/ok?token=c", srv.Listener.Addr().String()},
+		{[]ClientOption{}, "/ok?token=a", srv.URL + "/ok?token=a"},
+		{[]ClientOption{URLTagFunc(fn)}, "/ok?token=c", srv.URL + "/ok?token=*"},
 		// Disable ClientTrace to fire RoundTrip
 		{[]ClientOption{ClientTrace(false)}, "/ok?token=b", srv.URL + "/ok?token=b"},
 		{[]ClientOption{ClientTrace(false), URLTagFunc(fn)}, "/ok?token=c", srv.URL + "/ok?token=*"},


### PR DESCRIPTION
while creating spans for outbound requests, 
`http.url` tag is set In RoundTripper here: https://github.com/opentracing-contrib/go-stdlib/blob/60eb967dd2088de05ade698a1681103df3628bd4/nethttp/client.go#L188

but, if `clientTrace` is enabled, this http.url is overriden in `getConn()` with host:port. This leaves span with _poorer_ data with just host:port instead of complete (sanitised, if `URLTagFunc` was passed) url.
Some tools like https://www.hypertrace.org/ depend on `http.url` tag to determine backends of a service, for which they require a complete url.

Edit: based on conversation in https://github.com/opentracing-contrib/go-stdlib/pull/3#discussion_r95072111, made changes to set `peer.address` tag & log `hostPort` in `getConn()`