### PR TITLE
Pass span information on to the next RoundTripper

### DIFF
--- a/nethttp/client.go
+++ b/nethttp/client.go
@@ -193,7 +193,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		carrier := opentracing.HTTPHeadersCarrier(req.Header)
 		tracer.sp.Tracer().Inject(tracer.sp.Context(), opentracing.HTTPHeaders, carrier)
 	}
-
+	req = req.WithContext(opentracing.ContextWithSpan(req.Context(), tracer.sp))
 	resp, err := rt.RoundTrip(req)
 
 	if err != nil {


### PR DESCRIPTION
I'd like to log the span id / trace id with [jaegerzap.Trace](https://pkg.go.dev/github.com/uber/jaeger-client-go/log/zap#Trace) in the underlying RoundTripper that's invoked on the next line.  For that to work, the tracing span  needs to be in the request context, so this change puts that there.  I don't imagine this will break anyone else's code.  (And it would allow further RoundTrippers to contribute sub-spans to the trace, which could be useful to someone somewhere.)