### PR TITLE
Fix lint errors and add lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Run Unit Tests
-        run: go test -race -v ./...
+        run: go test -race -v -shuffle=on ./...
 
   draft-release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.ref_name }}-lint
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Go Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Lint Go
+        uses: golangci/golangci-lint-action@v6
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint Actions
+        uses: reviewdog/action-actionlint@v1
+        with:
+          actionlint_flags: -shellcheck ""

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,14 +33,14 @@ linters:
     - asasalint
     - asciicheck
     - bidichk
-    # - contextcheck
+    - contextcheck
+    - copyloopvar
     - dupword
     - durationcheck
     - errcheck
     - errchkjson
     - errname
     - errorlint
-    - exportloopref
     - fatcontext
     - forcetypeassert
     - gocheckcompilerdirectives
@@ -60,7 +60,7 @@ linters:
     - misspell
     - musttag
     - nilerr
-    # - noctx
+    - noctx
     - nolintlint
     - paralleltest
     - perfsprint
@@ -71,7 +71,6 @@ linters:
     - staticcheck
     - stylecheck
     - tagalign
-    - tenv
     - thelper
     - tparallel
     - typecheck
@@ -79,6 +78,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
     # - wrapcheck

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/opentracing-contrib/go-stdlib/actions/workflows/ci.yml/badge.svg)](https://github.com/opentracing-contrib/go-stdlib/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/opentracing-contrib/go-stdlib)](https://goreportcard.com/report/github.com/opentracing-contrib/go-stdlib)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/opentracing-contrib/go-stdlib)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/opentracing-contrib/ggo-stdlibc?logo=github&sort=semver)](https://github.com/opentracing-contrib/go-stdlib/releases/latest)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/opentracing-contrib/go-stdlib?logo=github&sort=semver)](https://github.com/opentracing-contrib/go-stdlib/releases/latest)
 
 This repository contains OpenTracing instrumentation for packages in
 the Go standard library.

--- a/nethttp/metrics-tracker.go
+++ b/nethttp/metrics-tracker.go
@@ -32,7 +32,7 @@ func (w *metricsTracker) Write(b []byte) (int, error) {
 func (w *metricsTracker) wrappedResponseWriter() http.ResponseWriter {
 	var (
 		hj, i0 = w.ResponseWriter.(http.Hijacker)
-		cn, i1 = w.ResponseWriter.(http.CloseNotifier) //nolint:staticcheck // TODO: Replace deprecated CloseNotifier
+		cn, i1 = w.ResponseWriter.(http.CloseNotifier) // TODO: Replace deprecated CloseNotifier
 		pu, i2 = w.ResponseWriter.(http.Pusher)
 		fl, i3 = w.ResponseWriter.(http.Flusher)
 		rf, i4 = w.ResponseWriter.(io.ReaderFrom)

--- a/nethttp/server_test.go
+++ b/nethttp/server_test.go
@@ -40,10 +40,16 @@ func TestOperationNameOption(t *testing.T) {
 			srv := httptest.NewServer(mw)
 			defer srv.Close()
 
-			_, err := http.Get(srv.URL)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				t.Fatalf("server returned error: %v", err)
 			}
+			defer resp.Body.Close()
 
 			spans := tr.FinishedSpans()
 			if got, want := len(spans), 1; got != want {
@@ -90,10 +96,16 @@ func TestSpanObserverOption(t *testing.T) {
 			srv := httptest.NewServer(mw)
 			defer srv.Close()
 
-			_, err := http.Get(srv.URL)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				t.Fatalf("server returned error: %v", err)
 			}
+			defer resp.Body.Close()
 
 			spans := tr.FinishedSpans()
 			if got, want := len(spans), 1; got != want {
@@ -198,10 +210,16 @@ func TestURLTagOption(t *testing.T) {
 			srv := httptest.NewServer(mw)
 			defer srv.Close()
 
-			_, err := http.Get(srv.URL + testCase.url)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+testCase.url, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				t.Fatalf("server returned error: %v", err)
 			}
+			defer resp.Body.Close()
 
 			spans := tr.FinishedSpans()
 			if got, want := len(spans), 1; got != want {
@@ -353,7 +371,12 @@ func BenchmarkStatusCodeTrackingOverhead(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			resp, err := http.Get(srv.URL)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				b.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				b.Fatalf("server returned error: %v", err)
 			}
@@ -380,7 +403,12 @@ func BenchmarkResponseSizeTrackingOverhead(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			resp, err := http.Get(srv.URL)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				b.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				b.Fatalf("server returned error: %v", err)
 			}
@@ -441,9 +469,17 @@ func TestMiddlewareHandlerPanic(t *testing.T) {
 			srv := httptest.NewServer(MiddlewareFunc(tr, mux.ServeHTTP))
 			defer srv.Close()
 
-			_, err := http.Get(srv.URL + "/root")
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/root", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				t.Logf("server returned error: %v", err)
+			}
+			if resp != nil {
+				defer resp.Body.Close()
 			}
 
 			spans := tr.FinishedSpans()

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"github>opentracing-contrib/common",
-		"schedule:daily"
+	  "github>opentracing-contrib/common",
+	  "schedule:weekly"
 	]
-}
+  }


### PR DESCRIPTION
This pull request includes several updates to CI workflows, linting configurations, and test improvements. The most important changes include renaming and updating the CI workflow, adding a new lint workflow, modifying the linting rules, and improving HTTP request handling in tests.

### CI Workflow Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R1): Renamed the workflow from "Go" to "CI" and updated the unit test command to include the `-shuffle=on` flag for better test reliability. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R1) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL32-R32)

### New Lint Workflow:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R45): Added a new workflow for linting Go code and GitHub Actions with concurrency control to cancel in-progress runs.

### Linting Configuration Updates:
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L36-L43): Enabled `contextcheck`, `copyloopvar`, `noctx`, and `usetesting` linters, and removed `exportloopref` and `tenv` linters to improve code quality. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L36-L43) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L63-R63) [[3]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L74-R81)

### Test Improvements:
* [`nethttp/server_test.go`](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL43-R52): Replaced `http.Get` with `http.NewRequestWithContext` and added proper error handling and response body closing to ensure resource cleanup and better test reliability. [[1]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL43-R52) [[2]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL93-R108) [[3]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL201-R222) [[4]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL356-R379) [[5]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL383-R411) [[6]](diffhunk://#diff-e4a87c6753094953b29d19577afe2dabbec6c4d1b6b775416493a7dca0a3405bL444-R483)

### Documentation Fix:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Corrected the GitHub release badge URL to fix a typo in the repository name.