### PR TITLE
Add middleware option to supply `StartSpanOption`s

### DIFF
--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -51,6 +51,7 @@ func MWSpanFilter(f func(r *http.Request) bool) MWOption {
 }
 
 // MWStartSpanOptions returns a MWOption that creates options for starting a span.
+// Middleware first applies default StartSpanOptions, followed by the ones supplied by the user.
 func MWStartSpanOptions(f func(r *http.Request) []opentracing.StartSpanOption) MWOption {
 	return func(options *mwOptions) {
 		options.startSpanOptions = f


### PR DESCRIPTION
This commit adds a middleware option that supplies `StartSpanOptions` for `StartSpan()` call. 

Concrete use case where this is useful: adding additional tags to the span through `opentracing.Tag{}` option, so that those tags could be used for deciding whether to sample this span.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP server middleware now supports custom OpenTracing span options, allowing developers to customize span creation and add custom tags for incoming requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentracing-contrib/go-stdlib/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->